### PR TITLE
Create PutShipCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -25,7 +25,7 @@ import seedu.address.model.cell.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing cell in the address book.
+ * Puts ship in an existing cell on the map.
  */
 public class PutShipCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -205,9 +205,13 @@ public class PutShipCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
-        public void setBattleship(Battleship battleship) { this.battleship = battleship; }
+        public void setBattleship(Battleship battleship) {
+            this.battleship = battleship;
+        }
 
-        public Optional<Battleship> getBattleship() { return Optional.ofNullable(battleship); }
+        public Optional<Battleship> getBattleship() {
+            return Optional.ofNullable(battleship);
+        }
 
         @Override
         public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -17,6 +17,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.battleship.Name;
 import seedu.address.model.cell.Address;
 import seedu.address.model.cell.Cell;
@@ -43,7 +44,8 @@ public class PutShipCommand extends Command {
             + PREFIX_COORDINATES + "c1";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Put ship in cell: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This cell already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This ship already exists on the map.";
+    public static final String MESSAGE_BATTLESHIP_PRESENT = "There is already a ship on the coordinate.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -72,8 +74,10 @@ public class PutShipCommand extends Command {
         Cell cellToEdit = lastShownList.get(index.getZeroBased());
         Cell editedCell = createEditedPerson(cellToEdit, editPersonDescriptor);
 
-        if (!cellToEdit.isSamePerson(editedCell) && model.hasPerson(editedCell)) {
+        if ((!cellToEdit.isSamePerson(editedCell) && model.hasPerson(editedCell))) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        } else if (cellToEdit.hasBattleShip()) {
+            throw new CommandException(MESSAGE_BATTLESHIP_PRESENT);
         }
 
         model.setPerson(cellToEdit, editedCell);
@@ -95,7 +99,9 @@ public class PutShipCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(cellToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(cellToEdit.getTags());
 
-        return new Cell(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        Battleship battleship = new Battleship(updatedName, updatedTags);
+
+        return new Cell(battleship);
     }
 
     @Override
@@ -126,6 +132,7 @@ public class PutShipCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private Battleship battleship;
 
         public EditPersonDescriptor() {}
 
@@ -139,6 +146,7 @@ public class PutShipCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setBattleship(toCopy.battleship);
         }
 
         /**
@@ -196,6 +204,10 @@ public class PutShipCommand extends Command {
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
+
+        public void setBattleship(Battleship battleship) { this.battleship = battleship; }
+
+        public Optional<Battleship> getBattleship() { return Optional.ofNullable(battleship); }
 
         @Override
         public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -1,0 +1,222 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.battleship.Name;
+import seedu.address.model.cell.Address;
+import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Email;
+import seedu.address.model.cell.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Edits the details of an existing cell in the address book.
+ */
+public class PutShipCommand extends Command {
+
+    public static final String COMMAND_WORD = "put";
+    public static final String COMMAND_ALIAS = "p";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Puts ship in cell that is identified "
+            + "by the row number provided by the user. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_COORDINATE + "COORDINATES]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NAME + "Destroyer "
+            + PREFIX_COORDINATE + "c1";
+
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Put ship in cell: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This cell already exists in the address book.";
+
+    private final Index index;
+    private final EditPersonDescriptor editPersonDescriptor;
+
+    /**
+     * @param index of the cell in the filtered cell list to edit
+     * @param editPersonDescriptor details to edit the cell with
+     */
+    public PutShipCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editPersonDescriptor);
+
+        this.index = index;
+        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Cell> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Cell cellToEdit = lastShownList.get(index.getZeroBased());
+        Cell editedCell = createEditedPerson(cellToEdit, editPersonDescriptor);
+
+        if (!cellToEdit.isSamePerson(editedCell) && model.hasPerson(editedCell)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.setPerson(cellToEdit, editedCell);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedCell));
+    }
+
+    /**
+     * Creates and returns a {@code Cell} with the details of {@code cellToEdit}
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Cell createEditedPerson(Cell cellToEdit, EditPersonDescriptor editPersonDescriptor) {
+        assert cellToEdit != null;
+
+        Name updatedName = editPersonDescriptor.getName().orElse(cellToEdit.getName());
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(cellToEdit.getPhone());
+        Email updatedEmail = editPersonDescriptor.getEmail().orElse(cellToEdit.getEmail());
+        Address updatedAddress = editPersonDescriptor.getAddress().orElse(cellToEdit.getAddress());
+        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(cellToEdit.getTags());
+
+        return new Cell(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PutShipCommand)) {
+            return false;
+        }
+
+        // state check
+        PutShipCommand e = (PutShipCommand) other;
+        return index.equals(e.index)
+                && editPersonDescriptor.equals(e.editPersonDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the cell with. Each non-empty field value will replace the
+     * corresponding field value of the cell.
+     */
+    public static class EditPersonDescriptor {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Set<Tag> tags;
+
+        public EditPersonDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+            setName(toCopy.name);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditPersonDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditPersonDescriptor e = (EditPersonDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getPhone().equals(e.getPhone())
+                    && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress())
+                    && getTags().equals(e.getTags());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -37,10 +37,10 @@ public class PutShipCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_COORDINATE + "COORDINATES]\n"
+            + "[" + PREFIX_COORDINATES + "COORDINATES]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Destroyer "
-            + PREFIX_COORDINATE + "c1";
+            + PREFIX_COORDINATES + "c1";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Put ship in cell: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This cell already exists in the address book.";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.InitialiseMapCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTagsCommand;
+import seedu.address.logic.commands.PutShipCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.StatsCommand;
@@ -95,6 +96,10 @@ public class AddressBookParser {
         case InitialiseMapCommand.COMMAND_WORD:
         case InitialiseMapCommand.COMMAND_ALIAS:
             return new InitialiseMapCommandParser().parse(arguments);
+
+        case PutShipCommand.COMMAND_WORD:
+        case PutShipCommand.COMMAND_ALIAS:
+            return new PutShipCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_MAP_SIZE = new Prefix("s/");
-
-    public static final Prefix PREFIX_COORDINATE = new Prefix("c/");
+    public static final Prefix PREFIX_COORDINATES = new Prefix("c/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.stream.Stream;
@@ -28,15 +28,15 @@ public class PutShipCommandParser implements Parser<PutShipCommand> {
     public PutShipCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COORDINATE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COORDINATES);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_COORDINATE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_COORDINATES)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PutShipCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Coordinates coordinates = ParserUtil.parseCoordinates(argMultimap.getValue(PREFIX_COORDINATE).get());
+        Coordinates coordinates = ParserUtil.parseCoordinates(argMultimap.getValue(PREFIX_COORDINATES).get());
 
 
         Index index = coordinates.getRowValue();

--- a/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.PutShipCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.PutShipCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.battleship.Name;
+import seedu.address.model.cell.Coordinates;
+
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
+public class PutShipCommandParser implements Parser<PutShipCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an EditCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PutShipCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COORDINATE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_COORDINATE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PutShipCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Coordinates coordinates = ParserUtil.parseCoordinates(argMultimap.getValue(PREFIX_COORDINATE).get());
+
+
+        Index index = coordinates.getRowValue();
+        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+
+        editPersonDescriptor.setName(name);
+
+        if (!editPersonDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new PutShipCommand(index, editPersonDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PutShipCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.PutShipCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.PutShipCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,13 +15,13 @@ import seedu.address.model.battleship.Name;
 import seedu.address.model.cell.Coordinates;
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new PutShipCommand object
  */
 public class PutShipCommandParser implements Parser<PutShipCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the PutShipCommand
+     * and returns an PutShipCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public PutShipCommand parse(String args) throws ParseException {
@@ -38,15 +37,10 @@ public class PutShipCommandParser implements Parser<PutShipCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Coordinates coordinates = ParserUtil.parseCoordinates(argMultimap.getValue(PREFIX_COORDINATES).get());
 
-
         Index index = coordinates.getRowValue();
+
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-
         editPersonDescriptor.setName(name);
-
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
-        }
 
         return new PutShipCommand(index, editPersonDescriptor);
     }

--- a/src/main/java/seedu/address/model/cell/Cell.java
+++ b/src/main/java/seedu/address/model/cell/Cell.java
@@ -59,7 +59,7 @@ public class Cell {
      */
     public Cell(Battleship battleship) {
         this.battleship = Optional.of(battleship);
-        this.name = new Name("This has a hidden ship");
+        this.name = battleship.getName();
         this.phone = new Phone("123");
         this.email = new Email("placeholder@gmail.com");
         this.address = new Address("placeholder");


### PR DESCRIPTION
Create PutShipCommand. See #29.

- Allow users to `put n/ship c/coordinates` on Cell in MapGrid.
- Checks if `battleship` is already present in the MapGrid. Returns error if so.
- Checks if `battleship` is already present on the Cell. Returns error if so.
- Show the name of `battleship` in the Cell once done.