### PR TITLE
Cell: Remove equals method override

### DIFF
--- a/src/main/java/seedu/address/model/cell/Cell.java
+++ b/src/main/java/seedu/address/model/cell/Cell.java
@@ -118,23 +118,6 @@ public class Cell {
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        if (!(other instanceof Cell)) {
-            return false;
-        }
-
-        Cell otherCell = (Cell) other;
-        return otherCell.getName().equals(getName())
-                && otherCell.getPhone().equals(getPhone())
-                && otherCell.getEmail().equals(getEmail())
-                && otherCell.getAddress().equals(getAddress())
-                && otherCell.getTags().equals(getTags());
-    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/seedu/address/model/cell/Cell.java
+++ b/src/main/java/seedu/address/model/cell/Cell.java
@@ -107,11 +107,9 @@ public class Cell {
     public boolean isSamePerson(Cell otherCell) {
         if (otherCell == this) {
             return true;
+        } else {
+            return false;
         }
-
-        return otherCell != null
-                && otherCell.getName().equals(getName())
-                && (otherCell.getPhone().equals(getPhone()) || otherCell.getEmail().equals(getEmail()));
     }
 
     /**


### PR DESCRIPTION
PutShip doesn't work properly with the current equals method present.
To be more specific, the indexOf method in list returns the first occurrence of any cell instead of the index specified by user.
Cell's can have the same attributes yet still be different cells.