### PR TITLE
Add putShip method in Model component

### DIFF
--- a/src/main/java/seedu/address/model/MapGrid.java
+++ b/src/main/java/seedu/address/model/MapGrid.java
@@ -9,7 +9,9 @@ import java.util.Set;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.InvalidationListenerManager;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Coordinates;
 import seedu.address.model.cell.Row;
 import seedu.address.model.cell.exceptions.DuplicatePersonException;
 import seedu.address.model.cell.exceptions.PersonNotFoundException;
@@ -193,5 +195,12 @@ public class MapGrid implements ReadOnlyAddressBook {
     @Override
     public int hashCode() {
         return persons.hashCode();
+    }
+
+    /**
+     * Put battleship in the given coordinates
+     */
+    public void putShip(Coordinates coordinates, Battleship battleship) {
+        persons.putShipAtIndex(coordinates.getRowValue(), battleship);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,7 +7,9 @@ import java.util.function.Predicate;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Coordinates;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -16,6 +18,11 @@ import seedu.address.model.tag.Tag;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Cell> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /**
+     * Put battleship in the given coordinates
+     */
+    void putShip(Coordinates coordinates, Battleship battleship);
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -18,7 +18,9 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Coordinates;
 import seedu.address.model.cell.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
 
@@ -53,6 +55,11 @@ public class ModelManager implements Model {
     }
 
     //=========== UserPrefs ==================================================================================
+
+    @Override
+    public void putShip(Coordinates coordinates, Battleship battleship) {
+        versionedAddressBook.putShip(coordinates, battleship);
+    }
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {

--- a/src/main/java/seedu/address/model/cell/Cell.java
+++ b/src/main/java/seedu/address/model/cell/Cell.java
@@ -19,7 +19,7 @@ import seedu.address.model.tag.Tag;
 public class Cell {
 
     // Identity fields
-    private final Name name;
+    private Name name;
     private final Phone phone;
     private final Email email;
 
@@ -93,6 +93,14 @@ public class Cell {
     }
 
     /**
+     * Put battleship in this cell
+     */
+    public void putShip(Battleship battleship) {
+        this.battleship = Optional.of(battleship);
+        this.name = battleship.getName();
+    }
+
+    /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
@@ -156,5 +164,4 @@ public class Cell {
         getTags().forEach(builder::append);
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/cell/Row.java
+++ b/src/main/java/seedu/address/model/cell/Row.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.exceptions.DuplicatePersonException;
 import seedu.address.model.cell.exceptions.PersonNotFoundException;
 
@@ -116,5 +118,9 @@ public class Row implements Iterable<Cell> {
     @Override
     public int hashCode() {
         return internalList.hashCode();
+    }
+
+    public void putShipAtIndex(Index index, Battleship battleship) {
+        internalList.get(index.getZeroBased()).putShip(battleship);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -24,7 +24,9 @@ import seedu.address.model.MapGrid;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Coordinates;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
@@ -94,6 +96,11 @@ public class AddCommandTest {
      * A default model stub that have all of the methods failing.
      */
     private class ModelStub implements Model {
+        @Override
+        public void putShip(Coordinates coordinates, Battleship battleship) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");


### PR DESCRIPTION
The current setPerson method in ModelManager can not be used in PutShipCommand because empty Cells have the same attributes i.e they are considered equal. So, setPerson does not edit the correct Cell to put the Battleship on.

putShip method in Model will take in Coordinates object and a Battleship object. 
This method will add the Battleship to the Cell
