### PR TITLE
Add tests for PutShipCommand

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COORDINATES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -37,6 +38,9 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_TAG_UNUSED = "unused";
+    public static final String VALID_COORDINATES_FIRST_ROW = "a1";
+    public static final String VALID_COORDINATES_MIDDLE_ROW = "e1";
+    public static final String VALID_COORDINATES_LAST_ROW = "j1";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -48,12 +52,20 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String COORDINATE_FIRST_ROW = " " + PREFIX_COORDINATES + VALID_COORDINATES_FIRST_ROW;
+    public static final String COORDINATE_MIDDLE_ROW = " " + PREFIX_COORDINATES + VALID_COORDINATES_MIDDLE_ROW;
+    public static final String COORDINATE_LAST_ROW = " " + PREFIX_COORDINATES + VALID_COORDINATES_LAST_ROW;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_COORDINATE_DESC_SYMBOLS = " " + PREFIX_COORDINATES
+            + "*1"; // symbols not allowed
+    public static final String INVALID_COORDINATE_DESC_OUT_OF_BOUNDS = " " + PREFIX_COORDINATES
+            + "z1"; // out of bounds, only characters between 'a' and 'j' are accepted
+
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
@@ -77,7 +89,7 @@ public class CommandTestUtil {
      * - the {@code actualCommandHistory} remains unchanged.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory,
-            CommandResult expectedCommandResult, Model expectedModel) {
+                                            CommandResult expectedCommandResult, Model expectedModel) {
         CommandHistory expectedCommandHistory = new CommandHistory(actualCommandHistory);
         try {
             CommandResult result = command.execute(actualModel, actualCommandHistory);
@@ -94,7 +106,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory,
-            String expectedMessage, Model expectedModel) {
+                                            String expectedMessage, Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, actualCommandHistory, expectedCommandResult, expectedModel);
     }
@@ -107,7 +119,7 @@ public class CommandTestUtil {
      * - {@code actualCommandHistory} remains unchanged.
      */
     public static void assertCommandFailure(Command command, Model actualModel, CommandHistory actualCommandHistory,
-            String expectedMessage) {
+                                            String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         MapGrid expectedMapGrid = new MapGrid(actualModel.getAddressBook());

--- a/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL;
+import static seedu.address.testutil.TypicalIndexes.COORDINATES_LAST_CELL;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Test;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.MapGrid;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.battleship.Battleship;
+import seedu.address.model.cell.Coordinates;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
+ */
+public class PutShipCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_battleshipAlreadyPresent_failure() {
+        Battleship battleship = new Battleship();
+        model.putShip(COORDINATES_FIRST_CELL, battleship);
+
+        PutShipCommand putShipCommand = new PutShipCommand(COORDINATES_FIRST_CELL, battleship);
+
+        Model expectedModel = new ModelManager(new MapGrid(model.getAddressBook()), new UserPrefs());
+        expectedModel.commitAddressBook();
+
+        assertCommandFailure(putShipCommand, model, commandHistory, PutShipCommand.MESSAGE_BATTLESHIP_PRESENT);
+    }
+
+    @Test
+    public void equals() {
+        final PutShipCommand standardCommand = new PutShipCommand(COORDINATES_FIRST_CELL, new Battleship());
+
+        // same values -> returns true
+        PutShipCommand commandWithSameValues = new PutShipCommand(new Coordinates("a1"), new Battleship());
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different coordinates -> returns false
+        assertFalse(standardCommand.equals(new PutShipCommand(COORDINATES_LAST_CELL, new Battleship())));
+
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.COORDINATES_LAST_CELL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.MapGrid;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/parser/PutShipCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PutShipCommandParserTest.java
@@ -14,7 +14,9 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.HashSet;
+
 import org.junit.Test;
+
 import seedu.address.logic.commands.PutShipCommand;
 import seedu.address.model.battleship.Battleship;
 import seedu.address.model.battleship.Name;

--- a/src/test/java/seedu/address/logic/parser/PutShipCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PutShipCommandParserTest.java
@@ -1,0 +1,83 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.COORDINATE_FIRST_ROW;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COORDINATE_DESC_OUT_OF_BOUNDS;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_COORDINATE_DESC_SYMBOLS;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COORDINATES_FIRST_ROW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COORDINATES_LAST_ROW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+import org.junit.Test;
+import seedu.address.logic.commands.PutShipCommand;
+import seedu.address.model.battleship.Battleship;
+import seedu.address.model.battleship.Name;
+import seedu.address.model.cell.Coordinates;
+import seedu.address.model.tag.Tag;
+
+public class PutShipCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, PutShipCommand.MESSAGE_USAGE);
+
+    private PutShipCommandParser parser = new PutShipCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // missing field coordinates
+        assertParseFailure(parser, NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // missing field name
+        assertParseFailure(parser, COORDINATE_FIRST_ROW, MESSAGE_INVALID_FORMAT);
+
+        // no fields specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + VALID_COORDINATES_LAST_ROW,
+                "Invalid command format! \n" + PutShipCommand.MESSAGE_USAGE);
+
+        // invalid coordinates and missing name
+        assertParseFailure(parser, INVALID_COORDINATE_DESC_SYMBOLS,
+                "Invalid command format! \n" + PutShipCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, INVALID_COORDINATE_DESC_OUT_OF_BOUNDS,
+                "Invalid command format! \n" + PutShipCommand.MESSAGE_USAGE);
+
+        // invalid name followed by valid coordinates
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_COORDINATE_DESC_SYMBOLS,
+                Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_COORDINATE_DESC_OUT_OF_BOUNDS,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // valid name followed by invalid coordinates.
+        assertParseFailure(parser, NAME_DESC_AMY + INVALID_COORDINATE_DESC_SYMBOLS,
+                Coordinates.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC_BOB + INVALID_COORDINATE_DESC_OUT_OF_BOUNDS,
+                Coordinates.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_COORDINATE_DESC_SYMBOLS,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        String userInput = NAME_DESC_AMY + COORDINATE_FIRST_ROW;
+
+        Battleship battleship = new Battleship(new Name(VALID_NAME_AMY),
+                1, 1, new HashSet<Tag>());
+        Coordinates coordinates = new Coordinates(VALID_COORDINATES_FIRST_ROW);
+        PutShipCommand expectedCommand = new PutShipCommand(coordinates, battleship);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/person/CoordinatesTest.java
+++ b/src/test/java/seedu/address/model/person/CoordinatesTest.java
@@ -45,14 +45,14 @@ public class CoordinatesTest {
     @Test
     public void testGetRow() {
         Coordinates coordinates = new Coordinates("b5");
-        Index correct_col_index = Index.fromOneBased(5);
-        assertEquals(coordinates.getColIndex(), correct_col_index);
+        Index correctColIndex = Index.fromOneBased(5);
+        assertEquals(coordinates.getColIndex(), correctColIndex);
     }
 
     @Test
     public void testGetCol() {
         Coordinates coordinates = new Coordinates("a1");
-        Index correct_col_index = Index.fromOneBased(1);
-        assertEquals(coordinates.getColIndex(), correct_col_index);
+        Index correctColIndex = Index.fromOneBased(1);
+        assertEquals(coordinates.getColIndex(), correctColIndex);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.cell.Coordinates;
 
 /**
  * A utility class containing a list of {@code Index} objects to be used in tests.
@@ -9,4 +10,7 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+
+    public static final Coordinates COORDINATES_FIRST_CELL = new Coordinates("a1");
+    public static final Coordinates COORDINATES_LAST_CELL = new Coordinates("j10");
 }


### PR DESCRIPTION
Summary of changes:

- Add valid and invalid coordinates to `CommandTestUtil.java`.
- Add coordinates to `TypicalIndexes.java`
- Add equality test and test for present battleship in `PutShipCommand`
- Add test for `PutShipCommandParser` for invalid and missing inputs.