### PR TITLE
Update PutShipCommand to put with length

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -83,7 +83,11 @@ public class PutShipCommand extends Command {
         if (cellToEdit.hasBattleShip()) {
             throw new CommandException(MESSAGE_BATTLESHIP_PRESENT);
         } else {
-            cellToEdit.putShip(battleship);
+            try {
+                putAlongHorizontal(model, coordinates, battleship);
+            } catch (Exception e) {
+                throw new CommandException(MESSAGE_BATTLESHIP_PRESENT_BODY_HORIZONTAL);
+            }
         }
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, cellToEdit));
@@ -165,6 +169,30 @@ public class PutShipCommand extends Command {
         }
 
         return true;
+    }
+
+    /**
+     * Puts the *same* battleship object along horizontal length.
+     * Pre-conditions: there are NO existing battleships along the horizontal length, else will throw
+     * and exception.
+     */
+    public static void putAlongHorizontal(Model model, Coordinates coordinates, Battleship battleship)
+            throws Exception {
+        Index rowIndex = coordinates.getRowIndex();
+        Index colIndex = coordinates.getColIndex();
+
+        int length = battleship.getLength();
+
+        for (int i = 0; i < length; i++) {
+            Cell cellToInspect = model.getMapGrid().getCell(rowIndex.getZeroBased(),
+                    colIndex.getZeroBased() + i);
+
+            if (cellToInspect.hasBattleShip()) {
+                throw new Exception();
+            } else {
+                cellToInspect.putShip(battleship);
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/PutShipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PutShipCommand.java
@@ -172,6 +172,30 @@ public class PutShipCommand extends Command {
     }
 
     /**
+     * Puts the *same* battleship object along vertical length.
+     * Pre-conditions: there are NO existing battleships along the vertical length, else will throw
+     * and exception.
+     */
+    public static void putAlongVertical(Model model, Coordinates coordinates, Battleship battleship)
+            throws Exception {
+        Index rowIndex = coordinates.getRowIndex();
+        Index colIndex = coordinates.getColIndex();
+
+        int length = battleship.getLength();
+
+        for (int i = 0; i < length; i++) {
+            Cell cellToInspect = model.getMapGrid().getCell(rowIndex.getZeroBased() + i,
+                    colIndex.getZeroBased());
+
+            if (cellToInspect.hasBattleShip()) {
+                throw new Exception();
+            } else {
+                cellToInspect.putShip(battleship);
+            }
+        }
+    }
+
+    /**
      * Puts the *same* battleship object along horizontal length.
      * Pre-conditions: there are NO existing battleships along the horizontal length, else will throw
      * and exception.

--- a/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL;
 import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL_NEXT_HORIZONTAL;
+import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL_NEXT_VERTICAL;
 import static seedu.address.testutil.TypicalIndexes.COORDINATES_LAST_CELL;
 import static seedu.address.testutil.TypicalIndexes.MAP_SIZE_TEN;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -39,6 +40,17 @@ public class PutShipCommandTest {
     }
 
     @Test
+    public void execute_putBattleshipVertical_failure() {
+        model.getMapGrid().initialise(MAP_SIZE_TEN);
+        Battleship battleship = new Battleship();
+        PutShipCommand putShipCommand = new PutShipCommand(COORDINATES_FIRST_CELL, battleship);
+        model.getMapGrid().getCell(COORDINATES_FIRST_CELL_NEXT_VERTICAL).putShip(battleship);
+
+        assertCommandFailure(putShipCommand, model, commandHistory,
+                PutShipCommand.MESSAGE_BATTLESHIP_PRESENT_BODY_VERTICAL);
+    }
+
+    @Test
     public void execute_putBattleshipHorizontal_failure() {
         model.getMapGrid().initialise(MAP_SIZE_TEN);
         Battleship battleship = new Battleship();
@@ -46,7 +58,7 @@ public class PutShipCommandTest {
         model.getMapGrid().getCell(COORDINATES_FIRST_CELL_NEXT_HORIZONTAL).putShip(battleship);
 
         assertCommandFailure(putShipCommand, model, commandHistory,
-                PutShipCommand.MESSAGE_BATTLESHIP_PRESENT_BODY_VERTICAL);
+                PutShipCommand.MESSAGE_BATTLESHIP_PRESENT_BODY_HORIZONTAL);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PutShipCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL;
+import static seedu.address.testutil.TypicalIndexes.COORDINATES_FIRST_CELL_NEXT_HORIZONTAL;
 import static seedu.address.testutil.TypicalIndexes.COORDINATES_LAST_CELL;
 import static seedu.address.testutil.TypicalIndexes.MAP_SIZE_TEN;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -29,10 +30,20 @@ public class PutShipCommandTest {
     public void execute_battleshipAlreadyPresent_failure() {
         model.getMapGrid().initialise(MAP_SIZE_TEN);
         Battleship battleship = new Battleship();
-        model.putShip(COORDINATES_FIRST_CELL, battleship);
         model.getMapGrid().getCell(COORDINATES_FIRST_CELL).putShip(battleship);
 
         PutShipCommand putShipCommand = new PutShipCommand(COORDINATES_FIRST_CELL, battleship);
+
+        assertCommandFailure(putShipCommand, model, commandHistory,
+                PutShipCommand.MESSAGE_BATTLESHIP_PRESENT_BODY_VERTICAL);
+    }
+
+    @Test
+    public void execute_putBattleshipHorizontal_failure() {
+        model.getMapGrid().initialise(MAP_SIZE_TEN);
+        Battleship battleship = new Battleship();
+        PutShipCommand putShipCommand = new PutShipCommand(COORDINATES_FIRST_CELL, battleship);
+        model.getMapGrid().getCell(COORDINATES_FIRST_CELL_NEXT_HORIZONTAL).putShip(battleship);
 
         assertCommandFailure(putShipCommand, model, commandHistory,
                 PutShipCommand.MESSAGE_BATTLESHIP_PRESENT_BODY_VERTICAL);

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -14,6 +14,7 @@ public class TypicalIndexes {
     public static final int MAP_SIZE_TEN = 10;
     public static final Coordinates COORDINATES_FIRST_CELL = new Coordinates("a1");
     public static final Coordinates COORDINATES_FIRST_CELL_NEXT_HORIZONTAL = new Coordinates("a2");
+    public static final Coordinates COORDINATES_FIRST_CELL_NEXT_VERTICAL = new Coordinates("b1");
 
     public static final Coordinates COORDINATES_LAST_CELL = new Coordinates("j10");
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -13,5 +13,7 @@ public class TypicalIndexes {
 
     public static final int MAP_SIZE_TEN = 10;
     public static final Coordinates COORDINATES_FIRST_CELL = new Coordinates("a1");
+    public static final Coordinates COORDINATES_FIRST_CELL_NEXT_HORIZONTAL = new Coordinates("a2");
+
     public static final Coordinates COORDINATES_LAST_CELL = new Coordinates("j10");
 }


### PR DESCRIPTION
Summary of changes:

* `PutShipCommand` puts `battleship` along horizontal and vertical lengths according to the length of the `battleship`.
* Added respective tests.

**Note!** The default behaviour is to add along horizontal length at the moment. I will update it to allow the user to include orientation in the near future.