### PR TITLE
Better encapsulation of MapGrid

### DIFF
--- a/src/main/java/seedu/address/model/MapGrid.java
+++ b/src/main/java/seedu/address/model/MapGrid.java
@@ -68,6 +68,14 @@ public class MapGrid implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns map size
+     */
+    public int getMapSize() {
+        return this.size;
+    }
+
+    // TODO: Remove getCell methods
+    /**
      * Returns the cell in the given coordinates
      */
     public Cell getCell(Coordinates coordinates) {
@@ -77,6 +85,8 @@ public class MapGrid implements ReadOnlyAddressBook {
     public Cell getCell(int row, int column) {
         return cellGrid[row][column];
     }
+
+    // UI operations
 
     /**
      * Used to Update the UI.
@@ -96,6 +106,23 @@ public class MapGrid implements ReadOnlyAddressBook {
         } else {
             uiUpdateSwitch.setValue(false);
         }
+    }
+
+    // Cell operations
+    /**
+     * Put battleship in the given coordinates
+     */
+    public void putShip(Coordinates coordinates, Battleship battleship) {
+        cellGrid[coordinates.getRowIndex().getZeroBased()][coordinates.getColIndex().getZeroBased()]
+            .putShip(battleship);
+    }
+
+    /**
+     * Attack a specified cell. Returns true if a ship was hit otherwise false.
+     */
+    public boolean attackCell(Coordinates coordinates) {
+        return cellGrid[coordinates.getRowIndex().getZeroBased()][coordinates.getColIndex().getZeroBased()]
+                .receiveAttack();
     }
 
     //// list overwrite operations
@@ -199,13 +226,6 @@ public class MapGrid implements ReadOnlyAddressBook {
         return tags;
     }
 
-    /**
-     * Returns map size
-     */
-    public int getMapSize() {
-        return this.size;
-    }
-
     @Override
     public void addListener(InvalidationListener listener) {
         invalidationListenerManager.addListener(listener);
@@ -246,12 +266,5 @@ public class MapGrid implements ReadOnlyAddressBook {
     @Override
     public int hashCode() {
         return persons.hashCode();
-    }
-
-    /**
-     * Put battleship in the given coordinates
-     */
-    public void putShip(Coordinates coordinates, Battleship battleship) {
-        persons.putShipAtIndex(coordinates.getRowIndex(), battleship);
     }
 }

--- a/src/main/java/seedu/address/model/MapGrid.java
+++ b/src/main/java/seedu/address/model/MapGrid.java
@@ -56,6 +56,7 @@ public class MapGrid implements ReadOnlyAddressBook {
         resetData(toBeCopied);
     }
 
+    // 2D map grid operations
     /**
      * Initialises the 2D Map from the given 2D Cell array
      */
@@ -65,6 +66,21 @@ public class MapGrid implements ReadOnlyAddressBook {
         for (int i = 0; i < size; i++) {
             cellGrid[i] = map[i].clone();
         }
+    }
+
+    /**
+     * Returns a copy of the map grid
+     */
+    public Cell[][] get2dArrayMapGridCopy() {
+        Cell[][] mapCopy = new Cell[size][size];
+
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                mapCopy[i][j] = new Cell(cellGrid[i][j]);
+            }
+        }
+
+        return mapCopy;
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -21,11 +21,6 @@ public interface Model {
     Predicate<Cell> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
-     * Put battleship in the given coordinates
-     */
-    void putShip(Coordinates coordinates, Battleship battleship);
-
-    /**
      * Update the UI
      */
     void updateUi();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,9 +8,7 @@ import javafx.beans.property.ReadOnlyProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
-import seedu.address.model.cell.Coordinates;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -19,9 +19,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
-import seedu.address.model.cell.Coordinates;
 import seedu.address.model.cell.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
 
@@ -56,11 +54,6 @@ public class ModelManager implements Model {
     }
 
     //=========== UserPrefs ==================================================================================
-
-    @Override
-    public void putShip(Coordinates coordinates, Battleship battleship) {
-        versionedAddressBook.putShip(coordinates, battleship);
-    }
 
     @Override
     public void updateUi() {

--- a/src/main/java/seedu/address/model/cell/Cell.java
+++ b/src/main/java/seedu/address/model/cell/Cell.java
@@ -64,6 +64,17 @@ public class Cell {
         this.address = new Address("placeholder");
     }
 
+    /**
+     * Constructor to copy a given Cell
+     */
+    public Cell(Cell newCell) {
+        this.battleship = newCell.battleship;
+        this.name = newCell.name;
+        this.phone = new Phone("123");
+        this.email = new Email("placeholder@gmail.com");
+        this.address = new Address("placeholder");
+    }
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -36,15 +36,20 @@ public class PersonListPanel extends UiPart<Region> {
         super(FXML);
         modelUpdateObservable.addListener(observable -> {
             int size = mapGrid.getMapSize();
+            Cell[][] mapArray = mapGrid.get2dArrayMapGridCopy();
+
             grid.getChildren().clear();
+
             for (int i = 0; i < size; i++) {
                 HBox row = new HBox();
                 for (int j = 0; j < size; j++) {
                     Rectangle cell = new Rectangle(30, 30);
-                    Cell mapCell = mapGrid.getCell(i, j);
+                    Cell mapCell = mapArray[i][j];
+
                     Color color = getColor(mapCell);
                     cell.setStroke(Color.BLACK);
                     cell.setFill(color);
+
                     Text text = new Text("");
                     StackPane sp = new StackPane();
                     sp.getChildren().addAll(cell, text);

--- a/src/test/java/seedu/address/model/MapGridTest.java
+++ b/src/test/java/seedu/address/model/MapGridTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_UNUSED;
 
+import static seedu.address.testutil.SizeTenMapGrid.getSizeTenMapGrid;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -24,7 +25,9 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import seedu.address.model.battleship.Battleship;
 import seedu.address.model.cell.Cell;
+import seedu.address.model.cell.Coordinates;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -35,6 +38,27 @@ public class MapGridTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private final MapGrid mapGrid = new MapGrid();
+
+    @Test
+    public void putShipTest() {
+        MapGrid sizeTenmap = getSizeTenMapGrid();
+        Battleship battleship = new Battleship();
+
+        sizeTenmap.putShip(new Coordinates("a1"), battleship);
+
+        assertEquals(sizeTenmap.get2dArrayMapGridCopy()[0][0].getBattleship().get(), battleship);
+    }
+
+    @Test
+    public void attackCellTest() {
+        MapGrid sizeTenmap = getSizeTenMapGrid();
+        Battleship battleship = new Battleship();
+
+        assertFalse(sizeTenmap.attackCell(new Coordinates("a1")));
+
+        sizeTenmap.putShip(new Coordinates("a1"), battleship);
+        assertTrue(sizeTenmap.attackCell(new Coordinates("a1")));
+    }
 
     @Test
     public void constructor() {

--- a/src/test/java/seedu/address/model/cell/CellTest.java
+++ b/src/test/java/seedu/address/model/cell/CellTest.java
@@ -42,6 +42,19 @@ public class CellTest {
     }
 
     @Test
+    public void copyConstructor() {
+        Cell emptyCell = new Cell();
+        Cell copyCell = new Cell(emptyCell);
+        assertEquals(emptyCell.getBattleship(), copyCell.getBattleship());
+
+        Cell battleShipCell = new Cell();
+        battleShipCell.putShip(new Battleship());
+        copyCell = new Cell(battleShipCell);
+
+        assertEquals(battleShipCell.getBattleship(), copyCell.getBattleship());
+    }
+
+    @Test
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
         Cell cell = new PersonBuilder().build();
         thrown.expect(UnsupportedOperationException.class);


### PR DESCRIPTION
Instead of having a getCell() method in MapGrid, have the putShip() and attackCell() directly from the MapGrid. 

Also, the UI now uses a copy of the 2D array map grid instead of the actual Cell.

Resolves #131 