### PR TITLE
Remove AB4 elements from Logic component

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -27,13 +27,6 @@ public interface Logic {
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
     /**
-     * Returns the MapGrid.
-     *
-     * @see seedu.address.model.Model#getAddressBook()
-     */
-    ReadOnlyAddressBook getAddressBook();
-
-    /**
      * Returns an unmodifiable view of the list of commands entered by the user.
      * The list is ordered from the least recent command to the most recent command.
      */

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -43,11 +43,6 @@ public interface Logic {
     ObservableList<String> getHistory();
 
     /**
-     * Returns the user prefs' address book file path.
-     */
-    Path getAddressBookFilePath();
-
-    /**
      * Returns the user prefs' GUI settings.
      */
     GuiSettings getGuiSettings();

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -68,11 +68,4 @@ public interface Logic {
      * Returns the enemy map grid
      */
     MapGrid getEnemyMapGrid();
-
-    /**
-     * Sets the selected cell in the filtered cell list.
-     *
-     * @see seedu.address.model.Model#setSelectedPerson(Cell)
-     */
-    void setSelectedPerson(Cell cell);
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -33,9 +33,6 @@ public interface Logic {
      */
     ReadOnlyAddressBook getAddressBook();
 
-    /** Returns an unmodifiable view of the filtered list of persons */
-    ObservableList<Cell> getFilteredPersonList();
-
     /**
      * Returns an unmodifiable view of the list of commands entered by the user.
      * The list is ordered from the least recent command to the most recent command.

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -50,14 +50,6 @@ public interface Logic {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Selected cell in the filtered cell list.
-     * null if no cell is selected.
-     *
-     * @see seedu.address.model.Model#selectedPersonProperty()
-     */
-    ReadOnlyProperty<Cell> selectedPersonProperty();
-
-    /**
      * Used for the Ui to listen to and trigger changes.
      */
     ObservableBooleanValue getHumanMapObservable();

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,8 +1,5 @@
 package seedu.address.logic;
 
-import java.nio.file.Path;
-
-import javafx.beans.property.ReadOnlyProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -10,8 +7,6 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.MapGrid;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.cell.Cell;
 
 /**
  * API of the Logic component

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -127,9 +127,4 @@ public class LogicManager implements Logic {
     public MapGrid getEnemyMapGrid() {
         return model.getEnemyMapGrid();
     }
-
-    @Override
-    public void setSelectedPerson(Cell cell) {
-        model.setSelectedPerson(cell);
-    }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,10 +1,8 @@
 package seedu.address.logic;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.logging.Logger;
 
-import javafx.beans.property.ReadOnlyProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -16,8 +14,6 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.MapGrid;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.cell.Cell;
 import seedu.address.model.statistics.PlayerStatistics;
 import seedu.address.storage.Storage;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -94,11 +94,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Cell> getFilteredPersonList() {
-        return model.getFilteredPersonList();
-    }
-
-    @Override
     public ObservableList<String> getHistory() {
         return history.getHistory();
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -104,11 +104,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getAddressBookFilePath() {
-        return model.getAddressBookFilePath();
-    }
-
-    @Override
     public GuiSettings getGuiSettings() {
         return model.getGuiSettings();
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -109,11 +109,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ReadOnlyProperty<Cell> selectedPersonProperty() {
-        return model.selectedPersonProperty();
-    }
-
-    @Override
     public ObservableBooleanValue getHumanMapObservable() {
         return model.getHumanMapObservable();
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -89,11 +89,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ReadOnlyAddressBook getAddressBook() {
-        return model.getAddressBook();
-    }
-
-    @Override
     public ObservableList<String> getHistory() {
         return history.getHistory();
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -65,12 +65,6 @@ public class LogicManagerTest {
     public void execute_storageThrowsIoException_throwsCommandException() throws Exception {
     }
 
-    @Test
-    public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        thrown.expect(UnsupportedOperationException.class);
-        logic.getFilteredPersonList().remove(0);
-    }
-
     /**
      * Executes the command, confirms that no exceptions are thrown and that the result message is correct.
      * Also confirms that {@code expectedModel} is as specified.


### PR DESCRIPTION
Summary of changes. Removal of the following methods and associated tests:

* `getAddressBookFilePath`
* `getFilteredPersonList`
* `selectedPersonProperty`
* `setSelectedPerson`
* `getAddressBook`

Removed unused imports in `Logic.java` and `LogicManager.java` as a result of the above purge. See #275 for more details.