### PR TITLE
Remove refs to Address in tests

### DIFF
--- a/src/test/java/seedu/address/model/battleship/BattleshipTest.java
+++ b/src/test/java/seedu/address/model/battleship/BattleshipTest.java
@@ -11,9 +11,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import seedu.address.model.cell.Address;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.Assert;
 
 public class BattleshipTest {
 

--- a/src/test/java/seedu/address/model/battleship/BattleshipTest.java
+++ b/src/test/java/seedu/address/model/battleship/BattleshipTest.java
@@ -20,17 +20,6 @@ public class BattleshipTest {
     private final Set<Tag> emptySet = new HashSet<>();
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> new Address(null));
-    }
-
-    @Test
-    public void constructor_invalidAddress_throwsIllegalArgumentException() {
-        String invalidAddress = "";
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Address(invalidAddress));
-    }
-
-    @Test
     public void testDefaultConstructors() {
         Battleship battleshipOne = new Battleship();
         Battleship battleshipTwo = new Battleship(new Name("destroyer"), new HashSet<>());

--- a/src/test/java/seedu/address/model/battleship/CoordinatesTest.java
+++ b/src/test/java/seedu/address/model/battleship/CoordinatesTest.java
@@ -14,17 +14,6 @@ import seedu.address.testutil.Assert;
 public class CoordinatesTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> new Address(null));
-    }
-
-    @Test
-    public void constructor_invalidAddress_throwsIllegalArgumentException() {
-        String invalidAddress = "";
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Address(invalidAddress));
-    }
-
-    @Test
     public void isValidCoordinates() {
         // null address
         Assert.assertThrows(NullPointerException.class, () -> Coordinates.isValidCoordinates(null));

--- a/src/test/java/seedu/address/model/battleship/CoordinatesTest.java
+++ b/src/test/java/seedu/address/model/battleship/CoordinatesTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.cell.Address;
 import seedu.address.model.cell.Coordinates;
 import seedu.address.testutil.Assert;
 


### PR DESCRIPTION
Remove references to Address in tests for Orientation, Battleship. See #336.